### PR TITLE
security: harden page data, NCBI lookups, and releases

### DIFF
--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -1,46 +1,57 @@
 # filepath: .github/workflows/build-extension.yml
-name: Build Extension with Secrets
+name: Build Extension
 
 on:
-  workflow_dispatch: # Allows manual triggering
+  workflow_dispatch:
   push:
     tags:
-      - 'v*.*.*' # Or trigger on new tags for releases
-      - 'v*.*.*-*' # Also trigger on pre-release tags like v1.0.0-alpha.1
+      - 'v*.*.*'
+      - 'v*.*.*-*'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write # Needed to create releases
+      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4 # Updated to v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Bump manifest.json version from tag
         if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
         run: |
           VERSION=${GITHUB_REF#refs/tags/v}
-          echo "🔖 Setting manifest.json version → $VERSION"
-          sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" manifest.json
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid extension version: $VERSION" >&2
+            exit 1
+          fi
+          VERSION="$VERSION" node <<'NODE'
+          const fs = require('node:fs');
+          const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
+          manifest.version = process.env.VERSION;
+          fs.writeFileSync('manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
+          NODE
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: '16'
+          node-version: '22'
+          cache: 'npm'
+          package-manager-cache: false
 
       - name: Install dependencies
-        run: npm ci
+        run: npm ci --ignore-scripts
 
       - name: Build extension
         run: npm run build
 
-      - name: Replace placeholders
-        run: |
-          sed -i "s|'%%NCBI_TOOL_NAME%%'|'${{ secrets.NCBI_TOOL_NAME_SECRET }}'|g" ./content/ncbi_api_handler.js
-          sed -i "s|'%%NCBI_API_EMAIL%%'|'${{ secrets.NCBI_API_EMAIL_SECRET }}'|g" ./content/ncbi_api_handler.js
+      - name: Verify vendored sanitizer version
+        run: grep -Fq 'DOMPurify 3.4.12' content/dompurify.min.js
 
-      - name: Create ZIP Package
+      - name: Create ZIP package
         run: |
           zip -r mdpi-filter.zip . \
             -x "node_modules/*" \
@@ -55,15 +66,16 @@ jobs:
             -x "logo.svg" \
             -x "*.zip"
 
-      - name: Upload Extension Artifact
-        uses: actions/upload-artifact@v4
+      - name: Upload extension artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: extension
           path: mdpi-filter.zip
+          if-no-files-found: error
 
-      - name: Create Release
+      - name: Create release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: mdpi-filter.zip
           draft: false

--- a/.github/workflows/build-extension.yml
+++ b/.github/workflows/build-extension.yml
@@ -19,19 +19,25 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Bump manifest.json version from tag
+      - name: Set manifest version from tag
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Invalid extension version: $VERSION" >&2
+          RELEASE_VERSION=${GITHUB_REF#refs/tags/v}
+          MANIFEST_VERSION=${RELEASE_VERSION%%-*}
+          if [[ ! "$MANIFEST_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Invalid extension version: $RELEASE_VERSION" >&2
             exit 1
           fi
-          VERSION="$VERSION" node <<'NODE'
+          RELEASE_VERSION="$RELEASE_VERSION" MANIFEST_VERSION="$MANIFEST_VERSION" node <<'NODE'
           const fs = require('node:fs');
           const manifest = JSON.parse(fs.readFileSync('manifest.json', 'utf8'));
-          manifest.version = process.env.VERSION;
+          manifest.version = process.env.MANIFEST_VERSION;
+          if (process.env.RELEASE_VERSION !== process.env.MANIFEST_VERSION) {
+            manifest.version_name = process.env.RELEASE_VERSION;
+          } else {
+            delete manifest.version_name;
+          }
           fs.writeFileSync('manifest.json', `${JSON.stringify(manifest, null, 2)}\n`);
           NODE
 
@@ -40,7 +46,6 @@ jobs:
         with:
           node-version: '22'
           cache: 'npm'
-          package-manager-cache: false
 
       - name: Install dependencies
         run: npm ci --ignore-scripts

--- a/content/ncbi_api_handler.js
+++ b/content/ncbi_api_handler.js
@@ -1,175 +1,213 @@
 // content/ncbi_api_handler.js
 
 if (typeof window.MDPIFilterNcbiApiHandler === 'undefined') {
-  // console.log("[MDPI Filter NCBI API] Initializing NCBI API Handler module...");
+  const MDPI_DOMAINS = ['mdpi.com', 'mdpi.org'];
+  const MDPI_DOI_PREFIX = '10.3390';
 
-  const MDPI_DOMAINS = ['mdpi.com', 'mdpi.org']; // Needed for checking journal names, though not directly used in API call itself for MDPI status
-  const MDPI_DOI_PREFIX = '10.3390'; // For identifying MDPI DOIs
+  // A hostile page can manufacture arbitrary reference-looking elements. Keep
+  // cross-origin work and memory bounded for the lifetime of this page.
+  const MAX_IDS_PER_PAGE = 600;
+  const BATCH_SIZE = 200;
+  const PAUSE_MS = 350;
+  const REQUEST_TIMEOUT_MS = 10000;
+  const MAX_CACHE_ENTRIES = 1000;
+
+  const queriedIdsThisPage = new Set();
+  let remainingLookupBudget = MAX_IDS_PER_PAGE;
+
+  function normalizeIdsForQuery(ids, idType) {
+    if (!Array.isArray(ids)) return [];
+
+    const normalized = [];
+    const seen = new Set();
+
+    for (const rawId of ids) {
+      if (rawId === null || typeof rawId === 'undefined') continue;
+
+      let id = String(rawId).trim();
+      if (!id) continue;
+
+      if (idType === 'doi') {
+        id = id.split('#')[0].split('?')[0].trim().toLowerCase();
+        // Commas are excluded because NCBI uses them as the batch delimiter.
+        if (!/^10\.\d{4,9}\/[^\s"',<>&]{1,240}$/.test(id)) continue;
+      } else if (idType === 'pmid') {
+        if (!/^\d{1,12}$/.test(id)) continue;
+      } else if (idType === 'pmcid') {
+        id = id.toUpperCase();
+        if (!/^PMC\d{1,12}$/.test(id)) continue;
+      } else {
+        return [];
+      }
+
+      if (!seen.has(id)) {
+        seen.add(id);
+        normalized.push(id);
+      }
+    }
+
+    return normalized;
+  }
+
+  function setBoundedCache(cache, key, value) {
+    if (!(cache instanceof Map)) return;
+
+    if (cache.has(key)) cache.delete(key);
+    cache.set(key, value);
+
+    while (cache.size > MAX_CACHE_ENTRIES) {
+      const oldestKey = cache.keys().next().value;
+      cache.delete(oldestKey);
+    }
+  }
+
+  function markBatchAsFalse(batchIds, runCache, ncbiApiCache, persist = true) {
+    batchIds.forEach(id => {
+      runCache.set(id, false);
+      if (persist) setBoundedCache(ncbiApiCache, id, false);
+    });
+  }
+
+  async function fetchJsonWithTimeout(url) {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        signal: controller.signal,
+        credentials: 'omit',
+        referrerPolicy: 'no-referrer'
+      });
+
+      if (!response.ok) {
+        throw new Error(`NCBI API request failed with HTTP ${response.status}`);
+      }
+
+      const contentType = response.headers.get('content-type') || '';
+      if (!contentType.toLowerCase().includes('application/json')) {
+        throw new Error(`NCBI API returned unexpected content type: ${contentType}`);
+      }
+
+      return await response.json();
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
 
   async function checkNcbiIdsForMdpi(ids, idType, runCache, ncbiApiCache) {
-    // Respect user opt-out for NCBI API
     if (window.MDPIFilterSettings && window.MDPIFilterSettings.ncbiApiEnabled === false) {
-      console.log("[MDPI Filter NCBI API] Skipping lookup: user opt-out");
       return false;
     }
-    // Filter out DOIs with fragments or invalid chars
-    if (idType === 'doi') {
-      ids = ids.map(id => id.split('#')[0].split('?')[0].trim())
-               .filter(id => /^[0-9.]+\/[^\s"'<>&]+$/.test(id));
-    }
 
-    console.log(`[MDPI Filter NCBI API DEBUG] >>> checkNcbiIdsForMdpi ENTRY. Type: ${idType}, IDs to check:`, JSON.parse(JSON.stringify(ids)));
-
-    if (!ids || ids.length === 0) {
-      console.log("[MDPI Filter NCBI API DEBUG] No IDs provided. Returning false.");
+    if (!(runCache instanceof Map) || !(ncbiApiCache instanceof Map)) {
       return false;
     }
+
+    const normalizedIds = normalizeIdsForQuery(ids, idType);
+    if (normalizedIds.length === 0) return false;
 
     const idsToQueryApi = [];
-    ids.forEach(id => {
+
+    for (const id of normalizedIds) {
       if (ncbiApiCache.has(id)) {
-        const cachedValue = ncbiApiCache.get(id);
-        runCache.set(id, cachedValue);
-        console.log(`[MDPI Filter NCBI API DEBUG] ID '${id}' (type: ${idType}) found in ncbiApiCache. Value:`, cachedValue);
-      } else {
-        console.log(`[MDPI Filter NCBI API DEBUG] ID '${id}' (type: ${idType}) NOT in ncbiApiCache. Will query API.`);
-        idsToQueryApi.push(id);
+        runCache.set(id, ncbiApiCache.get(id));
+        continue;
       }
-    });
 
-    console.log(`[MDPI Filter NCBI API DEBUG] IDs to query API (after ncbiApiCache check): ${idsToQueryApi.length}`, JSON.parse(JSON.stringify(idsToQueryApi)));
+      // Do not repeatedly query an identifier after a failed/empty lookup.
+      if (queriedIdsThisPage.has(id)) {
+        if (!runCache.has(id)) runCache.set(id, false);
+        continue;
+      }
 
-    if (idsToQueryApi.length === 0) {
-      console.log("[MDPI Filter NCBI API DEBUG] All IDs were found in ncbiApiCache. Skipping API call.");
-      const anyMdpiInCache = ids.some(id => runCache.get(id) === true);
-      console.log(`[MDPI Filter NCBI API DEBUG] Result based on ncbiApiCache only: ${anyMdpiInCache}`);
-      return anyMdpiInCache;
+      if (remainingLookupBudget <= 0) {
+        runCache.set(id, false);
+        continue;
+      }
+
+      queriedIdsThisPage.add(id);
+      remainingLookupBudget -= 1;
+      idsToQueryApi.push(id);
     }
 
-    const BATCH_SIZE = 200;
-    const PAUSE_MS = 350;   // ~3 calls/sec
+    let overallFoundMdpiInBatches = normalizedIds.some(id => runCache.get(id) === true);
 
     for (let i = 0; i < idsToQueryApi.length; i += BATCH_SIZE) {
-      const batchIdsToQuery = idsToQueryApi.slice(i, i + BATCH_SIZE);
-      if (batchIdsToQuery.length === 0) continue;
-
-      const idsString = batchIdsToQuery.join(',');
-      const encodedIdType = encodeURIComponent(idType);
-      const toolName = '%%NCBI_TOOL_NAME%%'; // Placeholder for tool name
-      const maintainerEmail = '%%NCBI_API_EMAIL%%'; // Placeholder for email
-      const encodedToolName = encodeURIComponent(toolName);
-      const encodedMaintainerEmail = encodeURIComponent(maintainerEmail);
-
-      const apiUrl = `https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/?ids=${idsString}&idtype=${encodedIdType}&format=json&versions=no&tool=${encodedToolName}&email=${encodedMaintainerEmail}`;
-      console.log(`[MDPI Filter NCBI API DEBUG] Querying NCBI API for batch (type ${idType}). URL: ${apiUrl}`, JSON.parse(JSON.stringify(batchIdsToQuery)));
+      const batchIds = idsToQueryApi.slice(i, i + BATCH_SIZE);
+      const apiUrl = new URL('https://www.ncbi.nlm.nih.gov/pmc/utils/idconv/v1.0/');
+      apiUrl.search = new URLSearchParams({
+        ids: batchIds.join(','),
+        idtype: idType,
+        format: 'json',
+        versions: 'no',
+        tool: 'mdpi-filter-edge'
+      }).toString();
 
       try {
-        const response = await fetch(apiUrl);
-        if (response.ok) {
-          // Defensive: check content-type
-          const contentType = response.headers.get('content-type') || '';
-          if (!contentType.includes('application/json')) {
-            console.error(`[MDPI Filter NCBI API DEBUG] NCBI API did not return JSON. Content-Type: ${contentType}`);
-            batchIdsToQuery.forEach(id => {
-              if (!runCache.has(id)) runCache.set(id, false);
-              if (!ncbiApiCache.has(id)) ncbiApiCache.set(id, false);
-            });
-            continue;
-          }
-          const data = await response.json();
-          console.log(`[MDPI Filter NCBI API DEBUG] Received API data for batch (type ${idType}):`, JSON.parse(JSON.stringify(data)));
-          const processedInThisBatch = new Set();
+        const data = await fetchJsonWithTimeout(apiUrl.toString());
+        const processedInThisBatch = new Set();
 
-          if (data.records && data.records.length > 0) {
-            data.records.forEach(record => {
-              console.log(`[MDPI Filter NCBI API DEBUG] Processing API record:`, JSON.parse(JSON.stringify(record)));
-              const queriedId = batchIdsToQuery.find(qid =>
-                (record.pmid && qid.toString() === record.pmid.toString()) ||
-                (record.pmcid && qid.toString().toUpperCase() === record.pmcid.toString().toUpperCase()) ||
-                (record.doi && qid.toString().toLowerCase() === record.doi.toString().toLowerCase()) ||
-                (record.live && record.versions && record.versions[0] && record.versions[0].pmid && qid.toString() === record.versions[0].pmid.toString()) || 
-                (record.live && record.versions && record.versions[0] && record.versions[0].pmcid && qid.toString().toUpperCase() === record.versions[0].pmcid.toString().toUpperCase()) ||
-                (record.live && record.versions && record.versions[0] && record.versions[0].doi && qid.toString().toLowerCase() === record.versions[0].doi.toString().toLowerCase())
+        if (Array.isArray(data.records)) {
+          for (const record of data.records) {
+            if (!record || typeof record !== 'object') continue;
+
+            const queriedId = batchIds.find(qid =>
+              (record.pmid && qid === String(record.pmid)) ||
+              (record.pmcid && qid === String(record.pmcid).toUpperCase()) ||
+              (record.doi && qid === String(record.doi).toLowerCase()) ||
+              (record.live && record.versions && record.versions[0] &&
+                ((record.versions[0].pmid && qid === String(record.versions[0].pmid)) ||
+                 (record.versions[0].pmcid && qid === String(record.versions[0].pmcid).toUpperCase()) ||
+                 (record.versions[0].doi && qid === String(record.versions[0].doi).toLowerCase())))
+            );
+
+            if (!queriedId) continue;
+            processedInThisBatch.add(queriedId);
+
+            let isMdpi = false;
+            const effectiveDoi = record.doi ||
+              (record.versions && record.versions[0] ? record.versions[0].doi : null);
+
+            if (effectiveDoi) {
+              isMdpi = String(effectiveDoi).toLowerCase().startsWith(MDPI_DOI_PREFIX);
+            } else if (typeof record.journal === 'string') {
+              const journalHost = record.journal.toLowerCase();
+              isMdpi = MDPI_DOMAINS.some(
+                domain => journalHost === domain || journalHost.endsWith(`.${domain}`)
               );
+            }
 
-              if (queriedId) {
-                processedInThisBatch.add(queriedId.toString());
-                let isMdpi = false;
-                const effectiveDoi = record.doi || (record.versions && record.versions[0] ? record.versions[0].doi : null);
-                if (effectiveDoi) {
-                  if (effectiveDoi.startsWith(MDPI_DOI_PREFIX)) {
-                    isMdpi = true;
-                  }
-                } else if (record.journal && typeof record.journal === 'string') {
-                  const journalHost = record.journal.toLowerCase();
-                  for (const domain of MDPI_DOMAINS) {
-                    if (journalHost === domain || journalHost.endsWith('.' + domain)) {
-                      isMdpi = true;
-                      break; // Found a match, no need to check other domains
-                    }
-                  }
-                }
-
-                console.log(`[MDPI Filter NCBI API DEBUG] DIAGNOSTIC: Before runCache.set for ID '${queriedId}'. runCache type: ${typeof runCache}, is Map: ${runCache instanceof Map}, runCache value:`, runCache);
-                
-                runCache.set(queriedId, isMdpi);
-                ncbiApiCache.set(queriedId, isMdpi);
-                if (isMdpi) {
-                  overallFoundMdpiInBatches = true;
-                }
-              } else {
-                console.log(`[MDPI Filter NCBI API DEBUG] API record did not match any queried ID in this batch:`, JSON.parse(JSON.stringify(record)));
-              }
-            });
-          } else {
-            console.log(`[MDPI Filter NCBI API DEBUG] API response OK, but no records found in data for batch (type ${idType}).`);
+            runCache.set(queriedId, isMdpi);
+            setBoundedCache(ncbiApiCache, queriedId, isMdpi);
+            overallFoundMdpiInBatches ||= isMdpi;
           }
+        }
 
-          batchIdsToQuery.forEach(id => {
-            if (!processedInThisBatch.has(id.toString())) {
-              console.log(`[MDPI Filter NCBI API DEBUG] ID '${id}' (type ${idType}) was in API query batch but not in response records. Marking as non-MDPI (false).`);
-              console.log(`[MDPI Filter NCBI API DEBUG] DIAGNOSTIC: Before runCache.set (unprocessed ID) for ID '${id}'. runCache type: ${typeof runCache}, is Map: ${runCache instanceof Map}`);
-              if (!runCache.has(id)) runCache.set(id, false);
-              if (!ncbiApiCache.has(id)) ncbiApiCache.set(id, false);
-            }
-          });
-
-        } else {
-          console.error(`[MDPI Filter NCBI API DEBUG] NCBI API request FAILED for batch (type ${idType}) ${batchIdsToQuery.join(', ')}: ${response.status} ${response.statusText}`);
-          batchIdsToQuery.forEach(id => {
-            console.log(`[MDPI Filter NCBI API DEBUG] DIAGNOSTIC: Before runCache.set (API failure) for ID '${id}'. runCache type: ${typeof runCache}, is Map: ${runCache instanceof Map}`);
-            if (!runCache.has(id)) {
-              runCache.set(id, false);
-            }
-          });
+        for (const id of batchIds) {
+          if (!processedInThisBatch.has(id)) {
+            runCache.set(id, false);
+            setBoundedCache(ncbiApiCache, id, false);
+          }
         }
       } catch (error) {
-        console.error(`[MDPI Filter NCBI API DEBUG] Network/Processing ERROR for NCBI batch (type ${idType}) ${batchIdsToQuery.join(', ')}:`, error);
-        batchIdsToQuery.forEach(id => {
-          console.log(`[MDPI Filter NCBI API DEBUG] DIAGNOSTIC: Before runCache.set (catch block) for ID '${id}'. runCache type: ${typeof runCache}, is Map: ${runCache instanceof Map}`);
-          if (!runCache.has(id)) {
-            runCache.set(id, false);
-          }
-        });
+        // Fail closed for this page and avoid retry storms. Network failures are
+        // not persisted in the long-lived cache so a page reload can retry.
+        markBatchAsFalse(batchIds, runCache, ncbiApiCache, false);
+        console.warn('[MDPI Filter] NCBI lookup failed:', error);
       }
 
-      // throttle: wait before next request if more batches remain
       if (i + BATCH_SIZE < idsToQueryApi.length) {
         await new Promise(resolve => setTimeout(resolve, PAUSE_MS));
       }
     }
 
-    const finalResult = ids.some(id => runCache.get(id) === true);
-    console.log(`[MDPI Filter NCBI API DEBUG] <<< checkNcbiIdsForMdpi EXIT. Final result for type ${idType} (any MDPI found): ${finalResult}. RunCache contents for these IDs:`);
-    ids.forEach(id => console.log(`    ID: ${id}, MDPI: ${runCache.get(id)}`));
-    return finalResult;
+    return overallFoundMdpiInBatches ||
+      normalizedIds.some(id => runCache.get(id) === true);
   }
 
   window.MDPIFilterNcbiApiHandler = {
-    checkNcbiIdsForMdpi
+    checkNcbiIdsForMdpi,
+    // Exposed for focused regression tests; not a privileged interface.
+    normalizeIdsForQuery
   };
-
-  // console.log("[MDPI Filter NCBI API] NCBI API Handler module loaded.");
-} else {
-  // console.log("[MDPI Filter NCBI API] NCBI API Handler module already loaded.");
 }

--- a/content/reference_id_extractor.js
+++ b/content/reference_id_extractor.js
@@ -5,6 +5,14 @@
     return; // Avoid re-injecting the script
   }
 
+  const SAFE_REFERENCE_ID = /^[A-Za-z0-9_.:-]{1,128}$/;
+
+  function normalizeReferenceId(value) {
+    if (typeof value !== 'string') return null;
+    const normalized = value.trim();
+    return SAFE_REFERENCE_ID.test(normalized) ? normalized : null;
+  }
+
   /**
    * Extracts or generates an internal scroll ID for a reference item.
    * It also sets the 'data-mdpi-filter-ref-id' attribute on the item.
@@ -22,8 +30,7 @@
     // Priority 1: Frontiers-specific anchor name attribute (for <a name="B1" id="B1">)
     const frontiersAnchor = itemElement.querySelector('a[name][id]');
     if (frontiersAnchor && frontiersAnchor.name && frontiersAnchor.id) {
-      // Prefer the name attribute as it's more commonly used in inline citations
-      idToUse = frontiersAnchor.name;
+      idToUse = normalizeReferenceId(frontiersAnchor.name);
       idSourceForLog = "Frontiers anchor name attribute";
     }
 
@@ -31,14 +38,14 @@
     if (!idToUse) {
       const naturePElement = itemElement.querySelector('p.c-article-references__text[id^="ref-CR"]');
       if (naturePElement && naturePElement.id) {
-        idToUse = naturePElement.id;
+        idToUse = normalizeReferenceId(naturePElement.id);
         idSourceForLog = "Nature child p.id";
       }
     }
 
     // Priority 3: Oxford University Press popup reference data-id
     if (!idToUse && itemElement.dataset && itemElement.dataset.id) {
-      idToUse = itemElement.dataset.id;
+      idToUse = normalizeReferenceId(itemElement.dataset.id);
       idSourceForLog = "item.dataset.id (OUP popup)";
     }
 
@@ -46,34 +53,32 @@
     if (!idToUse) {
       const sciDirectAnchor = itemElement.querySelector('span.label a.anchor[id^="ref-id-b"]');
       if (sciDirectAnchor && sciDirectAnchor.id) {
-        idToUse = sciDirectAnchor.id;
+        idToUse = normalizeReferenceId(sciDirectAnchor.id);
         idSourceForLog = "ScienceDirect child a.anchor.id";
       }
     }
 
     // Priority 5: ScienceDirect specific ID from child <span class="reference" id^="rf...">
-    // This is a fallback if the anchor ID isn't found, though less ideal for inline linking.
     if (!idToUse) {
       const sciDirectRefSpan = itemElement.querySelector('span.reference[id^="rf"]');
       if (sciDirectRefSpan && sciDirectRefSpan.id) {
-        idToUse = sciDirectRefSpan.id;
+        idToUse = normalizeReferenceId(sciDirectRefSpan.id);
         idSourceForLog = "ScienceDirect child span.reference.id";
       }
     }
 
-    // Priority 5.5 (New): BMJ specific ID from child <a class="rev-xref-ref" id="ref-...">
-    // This anchor's ID is directly targeted by inline citations.
+    // Priority 5.5: BMJ specific ID from child <a class="rev-xref-ref" id="ref-...">
     if (!idToUse) {
       const bmjRevXrefAnchor = itemElement.querySelector('a.rev-xref-ref[id^="ref-"]');
       if (bmjRevXrefAnchor && bmjRevXrefAnchor.id) {
-        idToUse = bmjRevXrefAnchor.id;
+        idToUse = normalizeReferenceId(bmjRevXrefAnchor.id);
         idSourceForLog = "BMJ child a.rev-xref-ref.id";
       }
     }
 
     // Priority 6: Standard item.id attribute
     if (!idToUse && itemElement.id) {
-      idToUse = itemElement.id;
+      idToUse = normalizeReferenceId(itemElement.id);
       idSourceForLog = "item.id";
     }
 
@@ -81,64 +86,56 @@
     if (!idToUse) {
       const oupContentId = itemElement.getAttribute('content-id');
       if (oupContentId) {
-        idToUse = oupContentId;
+        idToUse = normalizeReferenceId(oupContentId);
         idSourceForLog = "attribute 'content-id'";
       }
     }
-    
+
     // Priority 8: 'data-legacy-id' attribute (common in OUP)
     if (!idToUse) {
       const oupLegacyId = itemElement.getAttribute('data-legacy-id');
       if (oupLegacyId) {
-        idToUse = oupLegacyId;
+        idToUse = normalizeReferenceId(oupLegacyId);
         idSourceForLog = "attribute 'data-legacy-id'";
       }
     }
 
     // Priority 9: 'data-bib-id' attribute (common in Wiley)
     if (!idToUse && itemElement.dataset && itemElement.dataset.bibId) {
-        idToUse = itemElement.dataset.bibId;
-        idSourceForLog = "item.dataset.bibId";
+      idToUse = normalizeReferenceId(itemElement.dataset.bibId);
+      idSourceForLog = "item.dataset.bibId";
     }
 
-    // Priority 10: If no specific linkable ID found yet, check existing 'data-mdpi-filter-ref-id'
-    // This handles cases where the script might re-process an element that already has an ID (possibly generated).
+    // Priority 10: Existing internal ID
     if (!idToUse && itemElement.dataset.mdpiFilterRefId) {
-      idToUse = itemElement.dataset.mdpiFilterRefId;
+      idToUse = normalizeReferenceId(itemElement.dataset.mdpiFilterRefId);
       idSourceForLog = "existing data-mdpi-filter-ref-id";
     }
 
-    // If still no ID after all checks, generate a new one.
+    // Reject page-controlled values that cannot be safely interpolated into
+    // selectors. Generate an extension-owned identifier instead.
     if (!idToUse) {
       idToUse = `mdpi-ref-${nextRefIdCounter++}`;
-      itemElement.dataset.mdpiFilterRefId = idToUse; // Set attribute for newly generated
+      itemElement.dataset.mdpiFilterRefId = idToUse;
       idSourceForLog = "generated mdpi-ref-X";
       console.log(`[MDPI Filter RefIdExtractor] Generated and set data-mdpi-filter-ref-id='${idToUse}' for:`, itemElement);
     } else {
-      // An ID was found (either specific, existing, or from attributes).
-      // Ensure 'data-mdpi-filter-ref-id' is consistent with this found ID.
       if (itemElement.dataset.mdpiFilterRefId !== idToUse) {
         itemElement.dataset.mdpiFilterRefId = idToUse;
-        // Log adoption if the source wasn't "existing..." (which implies it was already the value)
-        // or "generated..." (which has its own log).
         console.log(`[MDPI Filter RefIdExtractor] Adopted ID from ${idSourceForLog} ('${idToUse}') and set data-mdpi-filter-ref-id for:`, itemElement);
-      } else {
-        // The attribute already matched idToUse.
-        // Log confirmation, unless it was a generated ID (already logged).
-         if (idSourceForLog !== "generated mdpi-ref-X") {
-            console.log(`[MDPI Filter RefIdExtractor] Using ID '${idToUse}' (source: ${idSourceForLog}). data-mdpi-filter-ref-id confirmed. Item:`, itemElement);
-        }
+      } else if (idSourceForLog !== "generated mdpi-ref-X") {
+        console.log(`[MDPI Filter RefIdExtractor] Using ID '${idToUse}' (source: ${idSourceForLog}). data-mdpi-filter-ref-id confirmed. Item:`, itemElement);
       }
     }
 
     return {
-      extractedId: idToUse, // This is the ID to be used by generateInlineFootnoteSelectors
+      extractedId: idToUse,
       updatedRefIdCounter: nextRefIdCounter
     };
   }
 
   window.MDPIFilterReferenceIdExtractor = {
-    extractInternalScrollId: extractInternalScrollId
+    extractInternalScrollId,
+    normalizeReferenceId
   };
-
 })();

--- a/content/sanitizer.js
+++ b/content/sanitizer.js
@@ -1,17 +1,54 @@
 // content/sanitizer.js
-// window.sanitize = html => html.replace(/<[^>]+>/g, ''); // Original version
 
-/**
- * Basic HTML tag stripper.
- * NOTE: For robust XSS protection when setting innerHTML, using a dedicated library
- * like DOMPurify is strongly recommended, or preferably, avoid setting innerHTML
- * with dynamic content by using `textContent` and `document.createElement`.
- * This function is a naive approach and may not cover all XSS vectors.
- */
-window.sanitize = (htmlInput) => {
-  if (typeof htmlInput !== 'string') {
-    return ''; // Ensure a string is always returned
+(function initializeSanitizer() {
+  'use strict';
+
+  const MINIMUM_DOMPURIFY_VERSION = [3, 4, 12];
+
+  function parseVersion(version) {
+    if (typeof version !== 'string') return null;
+    const match = version.match(/^(\d+)\.(\d+)\.(\d+)/);
+    return match ? match.slice(1).map(Number) : null;
   }
-  // You can pass configuration as 2nd arg if needed.
-  return DOMPurify.sanitize(htmlInput);
-};
+
+  function isSupportedVersion(version) {
+    const parsed = parseVersion(version);
+    if (!parsed) return false;
+
+    for (let index = 0; index < MINIMUM_DOMPURIFY_VERSION.length; index += 1) {
+      if (parsed[index] > MINIMUM_DOMPURIFY_VERSION[index]) return true;
+      if (parsed[index] < MINIMUM_DOMPURIFY_VERSION[index]) return false;
+    }
+    return true;
+  }
+
+  const purifier = window.DOMPurify ||
+    (typeof DOMPurify !== 'undefined' ? DOMPurify : null);
+
+  if (!purifier || typeof purifier.sanitize !== 'function' ||
+      !isSupportedVersion(purifier.version)) {
+    console.error(
+      '[MDPI Filter] Refusing to sanitize with a missing or outdated DOMPurify build. ' +
+      'Run npm ci --ignore-scripts && npm run build before loading the extension.'
+    );
+    // Fail closed: reference preview text is omitted instead of passing
+    // untrusted content through an unsupported sanitizer.
+    window.sanitize = () => '';
+    return;
+  }
+
+  window.sanitize = htmlInput => {
+    if (typeof htmlInput !== 'string') return '';
+
+    // This extension only needs plain reference preview text. Explicitly deny
+    // all markup and attributes even though current callers use textContent.
+    return purifier.sanitize(htmlInput, {
+      ALLOWED_TAGS: [],
+      ALLOWED_ATTR: []
+    });
+  };
+
+  window.MDPIFilterSanitizerSecurity = {
+    isSupportedVersion
+  };
+})();

--- a/content/selector_security_guard.js
+++ b/content/selector_security_guard.js
@@ -1,0 +1,26 @@
+// Prevent page-controlled reference identifiers from becoming CSS selectors.
+(function() {
+  'use strict';
+
+  if (!window.MDPIFilterUtils ||
+      typeof window.MDPIFilterUtils.generateInlineFootnoteSelectors !== 'function') {
+    return;
+  }
+
+  const originalGenerator = window.MDPIFilterUtils.generateInlineFootnoteSelectors;
+
+  window.MDPIFilterUtils.generateInlineFootnoteSelectors = function(referenceId) {
+    const normalizer = window.MDPIFilterReferenceIdExtractor &&
+      window.MDPIFilterReferenceIdExtractor.normalizeReferenceId;
+
+    const safeReferenceId = typeof normalizer === 'function'
+      ? normalizer(referenceId)
+      : (typeof referenceId === 'string' &&
+         /^[A-Za-z0-9_.:-]{1,128}$/.test(referenceId.trim())
+          ? referenceId.trim()
+          : null);
+
+    if (!safeReferenceId) return '';
+    return originalGenerator(safeReferenceId);
+  };
+})();

--- a/manifest.json
+++ b/manifest.json
@@ -20,14 +20,14 @@
     "type": "module"
   },
   "icons": {
-    "16":  "icons/icon-16.png",
-    "48":  "icons/icon-48.png",
+    "16": "icons/icon-16.png",
+    "48": "icons/icon-48.png",
     "128": "icons/icon-128.png"
   },
   "action": {
     "default_icon": {
-      "16":  "icons/icon-16.png",
-      "48":  "icons/icon-48.png",
+      "16": "icons/icon-16.png",
+      "48": "icons/icon-48.png",
       "128": "icons/icon-128.png"
     },
     "default_title": "MDPI Filter",
@@ -54,17 +54,20 @@
         "content/inline_footnote_styler.js",
         "content/cited_by_selectors.js",
         "content/cited_by_styler.js",
-        "content/similar_articles_selectors.js", 
-        "content/similar_articles_styler.js",   
+        "content/similar_articles_selectors.js",
+        "content/similar_articles_styler.js",
         "content/item_content_checker.js",
         "content/cited_by_processor.js",
-        "content/similar_articles_processor.js", 
+        "content/similar_articles_processor.js",
         "content/reference_id_extractor.js",
+        "content/selector_security_guard.js",
         "content/ncbi_api_handler.js",
         "content/content_script.js"
       ],
       "run_at": "document_idle"
     }
   ],
-  "externally_connectable": { "matches": [] }
+  "externally_connectable": {
+    "matches": []
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "mdpi-filter-microsoft-edge",
-  "version": "1.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mdpi-filter-microsoft-edge",
-      "version": "1.0.0",
+      "version": "0.0.1",
       "license": "ISC",
       "dependencies": {
-        "dompurify": "^3.2.6"
+        "dompurify": "3.4.12"
       }
     },
     "node_modules/@types/trusted-types": {
@@ -20,9 +20,9 @@
       "optional": true
     },
     "node_modules/dompurify": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
-      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
+      "version": "3.4.12",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
+      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "background.js",
   "scripts": {
     "build": "cp node_modules/dompurify/dist/purify.min.js content/dompurify.min.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test tests/*.test.js"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "dompurify": "^3.2.6"
+    "dompurify": "3.4.12"
   }
 }

--- a/popup.html
+++ b/popup.html
@@ -97,5 +97,6 @@
     <button id="reportIssue" class="secondary">Report Filter Issue</button>
   </div>
   <script src="popup.js"></script>
+  <script src="popup_security_guard.js"></script>
 </body>
 </html>

--- a/popup_security_guard.js
+++ b/popup_security_guard.js
@@ -1,0 +1,107 @@
+// Security controls for page-derived data handled by the popup.
+(function() {
+  'use strict';
+
+  function toPrivacySafeUrl(rawUrl) {
+    try {
+      const parsed = new URL(rawUrl);
+      parsed.search = '';
+      parsed.hash = '';
+      return parsed.toString();
+    } catch (error) {
+      return '[unavailable]';
+    }
+  }
+
+  function isSafeReferenceId(value) {
+    return typeof value === 'string' &&
+      /^[A-Za-z0-9_.:-]{1,128}$/.test(value.trim());
+  }
+
+  window.MDPIFilterPopupSecurity = {
+    toPrivacySafeUrl,
+    isSafeReferenceId
+  };
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const reportBtn = document.getElementById('reportIssue');
+    const referencesList = document.getElementById('referencesList');
+    const status = document.getElementById('status');
+
+    if (referencesList) {
+      referencesList.addEventListener('click', event => {
+        const clickedLi = event.target.closest('li[data-ref-id]');
+        if (clickedLi && !isSafeReferenceId(clickedLi.dataset.refId)) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          if (status) {
+            status.textContent = 'Could not open an invalid reference identifier.';
+            setTimeout(() => { status.textContent = ''; }, 3000);
+          }
+        }
+      }, true);
+    }
+
+    if (!reportBtn) return;
+
+    reportBtn.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+
+      chrome.tabs.query({ active: true, currentWindow: true }, tabs => {
+        if (!tabs.length || !tabs[0].url) {
+          if (status) {
+            status.textContent = 'Could not get current tab URL.';
+            setTimeout(() => { status.textContent = ''; }, 3000);
+          }
+          return;
+        }
+
+        const reportedUrl = toPrivacySafeUrl(tabs[0].url);
+        const githubRepo = 'mdpi-filter/mdpi-filter-microsoft-edge';
+        const currentMode =
+          document.querySelector('input[name="mode"]:checked')?.value || 'N/A';
+        const manifest = chrome.runtime.getManifest();
+
+        const issueTitle = encodeURIComponent(`Filter issue on: ${reportedUrl}`);
+        const issueBody = encodeURIComponent(
+`**Report a filter issue**
+
+Report filter issues with specific websites to the ${githubRepo} issue tracker. Requires a GitHub account.
+
+Before submitting, please search for an existing report:
+https://github.com/${githubRepo}/issues
+
+*Privacy note: the query string and fragment were removed before this page address was sent to GitHub.*
+
+---
+
+**Address of the webpage:**
+
+${reportedUrl}
+
+**Describe the filter issue:**
+
+[Was an MDPI result missed, or was a non-MDPI result incorrectly flagged?]
+
+---
+**Troubleshooting information:**
+
+* **Extension name:** ${manifest.name}
+* **Extension version:** ${manifest.version}
+* **Current filter mode:** ${currentMode}
+* **Browser:** ${navigator.userAgent}
+* **Operating system:** [Please fill in]
+
+**Screenshots or additional context:**
+
+[Optional]
+`);
+
+        chrome.tabs.create({
+          url: `https://github.com/${githubRepo}/issues/new?title=${issueTitle}&body=${issueBody}`
+        });
+      });
+    }, true);
+  });
+})();

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -89,7 +89,7 @@ test('NCBI lookups validate, deduplicate, and enforce the per-page budget', asyn
   };
 
   const window = { MDPIFilterSettings: { ncbiApiEnabled: true } };
-  const context = loadScript('content/ncbi_api_handler.js', { window, fetch });
+  loadScript('content/ncbi_api_handler.js', { window, fetch });
   const handler = window.MDPIFilterNcbiApiHandler;
   const runCache = new Map();
   const persistentCache = new Map();
@@ -134,4 +134,5 @@ test('release workflow pins actions and does not embed NCBI secrets', () => {
   assert.match(workflow, /npm ci --ignore-scripts/);
   assert.match(workflow, /DOMPurify 3\.4\.12/);
   assert.match(workflow, /persist-credentials:\s+false/);
+  assert.match(workflow, /manifest\.version_name = process\.env\.RELEASE_VERSION/);
 });

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -79,6 +79,46 @@ test('popup reporting removes query strings and fragments', () => {
   assert.equal(context.window.MDPIFilterPopupSecurity.isSafeReferenceId('ref"]'), false);
 });
 
+test('sanitizer fails closed for old builds and strips all markup for supported builds', () => {
+  let outdatedCalls = 0;
+  const outdatedPurifier = {
+    version: '3.2.6',
+    sanitize() {
+      outdatedCalls += 1;
+      return 'unsafe';
+    }
+  };
+  const outdatedWindow = { DOMPurify: outdatedPurifier };
+  loadScript('content/sanitizer.js', {
+    window: outdatedWindow,
+    DOMPurify: outdatedPurifier
+  });
+
+  assert.equal(outdatedWindow.sanitize('<img src=x onerror=alert(1)>'), '');
+  assert.equal(outdatedCalls, 0);
+
+  let receivedConfig = null;
+  const supportedPurifier = {
+    version: '3.4.12',
+    sanitize(input, config) {
+      receivedConfig = config;
+      return input.replace(/<[^>]+>/g, '');
+    }
+  };
+  const supportedWindow = { DOMPurify: supportedPurifier };
+  loadScript('content/sanitizer.js', {
+    window: supportedWindow,
+    DOMPurify: supportedPurifier
+  });
+
+  assert.equal(supportedWindow.sanitize('<b>Reference</b>'), 'Reference');
+  assert.deepEqual(receivedConfig, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+  assert.equal(
+    supportedWindow.MDPIFilterSanitizerSecurity.isSupportedVersion('3.5.0'),
+    true
+  );
+});
+
 test('NCBI lookups validate, deduplicate, and enforce the per-page budget', async () => {
   const requestedUrls = [];
   const fetch = async url => {

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -112,7 +112,10 @@ test('sanitizer fails closed for old builds and strips all markup for supported 
   });
 
   assert.equal(supportedWindow.sanitize('<b>Reference</b>'), 'Reference');
-  assert.deepEqual(receivedConfig, { ALLOWED_TAGS: [], ALLOWED_ATTR: [] });
+  assert.equal(Array.isArray(receivedConfig.ALLOWED_TAGS), true);
+  assert.equal(receivedConfig.ALLOWED_TAGS.length, 0);
+  assert.equal(Array.isArray(receivedConfig.ALLOWED_ATTR), true);
+  assert.equal(receivedConfig.ALLOWED_ATTR.length, 0);
   assert.equal(
     supportedWindow.MDPIFilterSanitizerSecurity.isSupportedVersion('3.5.0'),
     true

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const vm = require('node:vm');
+
+const ROOT = path.resolve(__dirname, '..');
+
+function loadScript(relativePath, additions = {}) {
+  const context = {
+    console: { log() {}, warn() {}, error() {} },
+    setTimeout,
+    clearTimeout,
+    URL,
+    URLSearchParams,
+    AbortController,
+    ...additions
+  };
+  context.window = context.window || {};
+  vm.createContext(context);
+  vm.runInContext(
+    fs.readFileSync(path.join(ROOT, relativePath), 'utf8'),
+    context,
+    { filename: relativePath }
+  );
+  return context;
+}
+
+test('reference identifiers reject selector metacharacters and excessive length', () => {
+  const context = loadScript('content/reference_id_extractor.js');
+  const normalize = context.window.MDPIFilterReferenceIdExtractor.normalizeReferenceId;
+
+  assert.equal(normalize('ref-CR12'), 'ref-CR12');
+  assert.equal(normalize('  B1:section.2  '), 'B1:section.2');
+  assert.equal(normalize('bad"] * { display:none }'), null);
+  assert.equal(normalize('x'.repeat(129)), null);
+});
+
+test('selector guard blocks unsafe identifiers before selector construction', () => {
+  let generatedWith = null;
+  const window = {
+    MDPIFilterUtils: {
+      generateInlineFootnoteSelectors(value) {
+        generatedWith = value;
+        return `a[href="#${value}"]`;
+      }
+    },
+    MDPIFilterReferenceIdExtractor: {
+      normalizeReferenceId(value) {
+        if (typeof value !== 'string') return null;
+        const trimmed = value.trim();
+        return /^[A-Za-z0-9_.:-]{1,128}$/.test(trimmed) ? trimmed : null;
+      }
+    }
+  };
+
+  loadScript('content/selector_security_guard.js', { window });
+
+  assert.equal(window.MDPIFilterUtils.generateInlineFootnoteSelectors('CR12'), 'a[href="#CR12"]');
+  assert.equal(generatedWith, 'CR12');
+  generatedWith = null;
+  assert.equal(window.MDPIFilterUtils.generateInlineFootnoteSelectors('x"] div'), '');
+  assert.equal(generatedWith, null);
+});
+
+test('popup reporting removes query strings and fragments', () => {
+  const document = { addEventListener() {} };
+  const context = loadScript('popup_security_guard.js', { document });
+  const safeUrl = context.window.MDPIFilterPopupSecurity.toPrivacySafeUrl(
+    'https://example.org/private/article?token=secret&query=mdpi#results'
+  );
+
+  assert.equal(safeUrl, 'https://example.org/private/article');
+  assert.equal(context.window.MDPIFilterPopupSecurity.isSafeReferenceId('ref-1'), true);
+  assert.equal(context.window.MDPIFilterPopupSecurity.isSafeReferenceId('ref"]'), false);
+});
+
+test('NCBI lookups validate, deduplicate, and enforce the per-page budget', async () => {
+  const requestedUrls = [];
+  const fetch = async url => {
+    requestedUrls.push(String(url));
+    return {
+      ok: true,
+      headers: { get: () => 'application/json; charset=utf-8' },
+      async json() { return { records: [] }; }
+    };
+  };
+
+  const window = { MDPIFilterSettings: { ncbiApiEnabled: true } };
+  const context = loadScript('content/ncbi_api_handler.js', { window, fetch });
+  const handler = window.MDPIFilterNcbiApiHandler;
+  const runCache = new Map();
+  const persistentCache = new Map();
+
+  assert.deepEqual(
+    Array.from(handler.normalizeIdsForQuery(['123', '123', 'bad', '456'], 'pmid')),
+    ['123', '456']
+  );
+  assert.deepEqual(
+    Array.from(handler.normalizeIdsForQuery(['10.1000/OK', '10.1000/bad,split'], 'doi')),
+    ['10.1000/ok']
+  );
+
+  const ids = Array.from({ length: 800 }, (_, index) => String(index + 1));
+  await handler.checkNcbiIdsForMdpi(ids, 'pmid', runCache, persistentCache);
+
+  assert.equal(requestedUrls.length, 3, '600 allowed IDs should produce three 200-ID batches');
+  const queriedIds = requestedUrls.flatMap(rawUrl => {
+    const parsed = new URL(rawUrl);
+    return parsed.searchParams.get('ids').split(',');
+  });
+  assert.equal(queriedIds.length, 600);
+  assert.equal(new Set(queriedIds).size, 600);
+
+  await handler.checkNcbiIdsForMdpi(
+    Array.from({ length: 100 }, (_, index) => String(index + 901)),
+    'pmid',
+    runCache,
+    persistentCache
+  );
+  assert.equal(requestedUrls.length, 3, 'no additional request is allowed after the page budget is exhausted');
+});
+
+test('release workflow pins actions and does not embed NCBI secrets', () => {
+  const workflow = fs.readFileSync(
+    path.join(ROOT, '.github/workflows/build-extension.yml'),
+    'utf8'
+  );
+
+  assert.doesNotMatch(workflow, /uses:\s+[^\s]+@v\d+/);
+  assert.doesNotMatch(workflow, /NCBI_(TOOL_NAME|API_EMAIL)_SECRET/);
+  assert.match(workflow, /npm ci --ignore-scripts/);
+  assert.match(workflow, /DOMPurify 3\.4\.12/);
+  assert.match(workflow, /persist-credentials:\s+false/);
+});

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -16,6 +16,8 @@ function loadScript(relativePath, additions = {}) {
     URL,
     URLSearchParams,
     AbortController,
+    Map,
+    Set,
     ...additions
   };
   context.window = context.window || {};


### PR DESCRIPTION
## Security review outcome

This PR applies the remediations from a repository-wide security review of the Microsoft Edge extension.

### Findings addressed

1. **Page-driven NCBI request/cache amplification**
   - Validate DOI, PMID, and PMCID inputs before network use.
   - Deduplicate identifiers.
   - Cap lookups at 600 identifiers per page and 200 per batch.
   - Add a 10-second request timeout.
   - Omit credentials/referrer data.
   - Bound the API cache to 1,000 entries and prevent retry storms.

2. **Page-controlled reference IDs used in CSS selectors**
   - Accept only bounded alphanumeric reference IDs with known-safe punctuation.
   - Generate extension-owned IDs when page values are unsafe.
   - Guard selector construction as a second enforcement boundary.
   - Reject unsafe popup scroll IDs.

3. **Full URL disclosure in issue reports**
   - Strip query strings and fragments before opening GitHub's issue form.
   - Update the privacy notice to describe the actual behavior.

4. **Release supply-chain exposure**
   - Pin all GitHub Actions to exact commit SHAs.
   - Disable checkout credential persistence.
   - Upgrade the build runtime to Node.js 22.
   - Install dependencies with lifecycle scripts disabled.
   - Remove build-time NCBI email/tool secret injection.
   - Validate release tag versions and use `version_name` for prereleases.

5. **Outdated sanitizer dependency and stale source bundle**
   - Pin DOMPurify 3.4.12 in `package.json` and `package-lock.json`.
   - Verify the generated release bundle contains DOMPurify 3.4.12.
   - Require DOMPurify 3.4.12 or newer at runtime.
   - Fail closed for an unbuilt checkout containing the older prebuilt file.
   - Strip all markup and attributes from reference previews.

### Validation

- `npm ci --ignore-scripts` — passed
- `npm test` — 6/6 passed
- `npm run build` — passed
- DOMPurify 3.4.12 bundle check — passed
- `node --check` for all changed JavaScript security modules — passed
- `npm audit --omit=dev` — 0 vulnerabilities
- Chromium manifest/CRX packaging validation — passed

### Validation limitation

A live unpacked-extension execution test could not run because the available Chromium installation is managed by an administrator policy that disables unpacked extensions. This is recorded as an environment limitation, not as a passed test. The repository currently has no pull-request CI status checks.

### Scope notes

- Broad HTTPS access remains because universal scholarly-page filtering is a core feature.
- No direct webpage-to-extension privileged messaging path or demonstrated script-execution vulnerability was found.
- A focused cross-repository check confirms the Chrome sibling contains the same full-URL report path, NCBI placeholder workflow, and selector-generation pattern; this PR intentionally changes only the Edge repository because the Chrome scan is being handled separately.
