### PR TITLE
docs: publish integrity privacy policy and store release gate

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,54 @@
+# Privacy policy
+
+Last updated: 22 July 2026
+
+MDPI Filter is designed to identify MDPI-related content and, when research-integrity lookups are enabled, check scholarly DOI identifiers for formal post-publication updates.
+
+## Data processed locally
+
+The extension may inspect the current webpage to find:
+
+- DOI identifiers for the current scholarly work;
+- DOI identifiers and short citation text in a visible bibliography;
+- MDPI-related links and references needed for its existing detection features.
+
+This processing occurs inside the browser. Article text, bibliography text, search queries, and the complete address or browsing history are not sent to the research-integrity provider.
+
+## Data sent for integrity lookups
+
+When **Check DOI integrity status with Crossref** is enabled, the extension sends normalized DOI identifiers to the Crossref REST API solely to retrieve scholarly metadata and post-publication update relationships, including retractions, expressions of concern, corrections, reinstatements, withdrawals/removals, and related notices.
+
+Requests:
+
+- omit cookies and other credentials;
+- use a no-referrer policy;
+- do not include the webpage address, article text, citation text, account identifiers, or analytics identifiers;
+- are limited and rate-spaced to respect Crossref's public service.
+
+Crossref operates independently and its own privacy terms apply to requests it receives.
+
+## Storage
+
+The extension stores user settings in browser synchronization storage. Lookup responses are cached only in the extension service worker's memory and may disappear when the worker stops. The extension does not create an analytics profile or persistent browsing-history database.
+
+## User control
+
+Integrity lookups can be disabled at any time from the extension popup. Disabling them stops new DOI requests. Existing MDPI detection continues to work, subject to its separate NCBI lookup preference.
+
+## Coverage and limitations
+
+The extension may limit the number of DOI checks on pages with very large bibliographies and reports deferred or unresolved identifiers instead of treating them as clear. A message that no known signal was found means only that none was found in the checked sources.
+
+## Logging
+
+Diagnostic logging is disabled by default. When enabled by the user, logs remain in the browser's developer console unless the user manually copies or submits them.
+
+## Reports and support
+
+Issue reports are submitted only when the user chooses to open GitHub. The prefilled report omits query strings and URL fragments, but users should remove any information they do not want to publish before submitting.
+
+Security reports should follow `SECURITY.md`. Privacy questions and correction requests may be opened in the repository issue tracker without including sensitive personal information.
+
+## Changes
+
+Material changes to data collection, recipients, or purposes will be documented here and in release notes before the corresponding extension update is published.

--- a/docs/store-release-checklist.md
+++ b/docs/store-release-checklist.md
@@ -1,0 +1,43 @@
+# Microsoft Edge Add-ons release checklist
+
+The `0.1.0` research-integrity preview must not be submitted until every item is evidenced.
+
+## Package and provenance
+
+- [ ] Use the ZIP produced by the successful GitHub Actions run for the release commit.
+- [ ] Record the commit SHA, workflow run, artifact checksum, manifest version, and package size.
+- [ ] Verify ZIP integrity and confirm there are no untracked/generated runtime files.
+- [ ] Retain the previous store package and rollback instructions.
+
+## Privacy disclosure
+
+- [ ] Publish `PRIVACY.md` at a stable public URL.
+- [ ] Update the Microsoft Edge Add-ons privacy declarations to disclose DOI identifiers/website content used for the user-requested integrity feature.
+- [ ] State that DOI identifiers are sent to Crossref solely for scholarly metadata/status lookup.
+- [ ] State that page/article text, full URLs, search queries, browsing history, account identifiers, and analytics identifiers are not sent.
+- [ ] Confirm the declared purpose is single-purpose functionality, not advertising, profiling, or sale.
+- [ ] Verify the store listing and privacy policy use identical descriptions.
+
+## Runtime evidence
+
+- [ ] Inspect browser network traffic on retraction, concern, correction, reinstatement, duplicate-publication, clean, unresolved, and more-than-50-DOI fixtures.
+- [ ] Confirm every Crossref request contains only the DOI in the endpoint and sends no cookies or referrer.
+- [ ] Confirm request starts remain at or below four per second.
+- [ ] Confirm disabling integrity lookups causes zero Crossref requests.
+- [ ] Confirm deferred, unresolved, and failed counts are displayed and never labeled safe/clear.
+- [ ] Confirm toolbar badge counts affected works once, not notices.
+- [ ] Confirm existing MDPI detection still works when no integrity signal is present.
+
+## Accessibility and presentation
+
+- [ ] Verify each status has icon, text, and color; color is not the sole signal.
+- [ ] Verify keyboard navigation, focus visibility, screen-reader labels, light mode, and dark mode.
+- [ ] Capture store screenshots showing counters, event chronology/provenance, coverage, and the privacy toggle.
+- [ ] Update release notes with limitations and data-source attribution.
+
+## Rollout
+
+- [ ] Publish to a small staged percentage first.
+- [ ] Monitor only Edge Add-ons aggregate diagnostics; do not add product analytics.
+- [ ] Expand only after checking error reports and false-positive reports.
+- [ ] Stop or roll back if privacy behavior, request load, or status classification differs from the validated artifact.


### PR DESCRIPTION
## Summary

- add a public privacy policy covering local DOI extraction, Crossref requests, omitted data, storage, user control, coverage limitations, logging, and issue reporting
- add a Microsoft Edge Add-ons checklist that blocks `0.1.0` publication until package provenance, store declarations, network inspection, opt-out behavior, accessibility, screenshots, staged rollout, and rollback are evidenced

No runtime behavior changes.